### PR TITLE
fix(security): patch critical vulnerabilities across storefront

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -43,8 +43,7 @@ export default async function handleRequest(
   }
 
   responseHeaders.set("Content-Type", "text/html");
-  // TODO: change to Content-Security-Policy when you ready with your CSP configs.
-  responseHeaders.set("Content-Security-Policy-Report-Only", header);
+  responseHeaders.set("Content-Security-Policy", header);
   return new Response(body, {
     headers: responseHeaders,
     status: responseStatusCode,

--- a/app/routes/($locale).api.$version.[graphql.json].tsx
+++ b/app/routes/($locale).api.$version.[graphql.json].tsx
@@ -1,12 +1,44 @@
 import type { LoaderFunctionArgs } from "react-router";
 
+const ALLOWED_VERSIONS = new Set([
+  "2024-01",
+  "2024-04",
+  "2024-07",
+  "2024-10",
+  "2025-01",
+  "2025-04",
+  "unstable",
+]);
+
 export async function action({ params, context, request }: LoaderFunctionArgs) {
+  // Validate API version to prevent URL manipulation
+  if (!params.version || !ALLOWED_VERSIONS.has(params.version)) {
+    return new Response("Invalid API version", { status: 400 });
+  }
+
+  // Only allow same-origin requests
+  const origin = request.headers.get("Origin");
+  const url = new URL(request.url);
+  if (origin && origin !== url.origin) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  // Forward only safe headers
+  const forwardHeaders = new Headers();
+  const safeHeaders = ["content-type", "accept", "accept-language"];
+  for (const name of safeHeaders) {
+    const value = request.headers.get(name);
+    if (value) {
+      forwardHeaders.set(name, value);
+    }
+  }
+
   const response = await fetch(
     `https://${context.env.PUBLIC_CHECKOUT_DOMAIN}/api/${params.version}/graphql.json`,
     {
       method: "POST",
       body: request.body,
-      headers: request.headers,
+      headers: forwardHeaders,
     },
   );
 

--- a/app/routes/($locale).api.customer.ts
+++ b/app/routes/($locale).api.customer.ts
@@ -1,6 +1,7 @@
 import type { ActionFunction, ActionFunctionArgs } from "react-router";
 import { data } from "react-router";
 import type { CustomerCreateMutation } from "storefront-api.generated";
+import { verifyTurnstile } from "~/utils/turnstile.server";
 
 const CUSTOMER_CREATE = `#graphql
   mutation customerCreate($input: CustomerCreateInput!) {
@@ -20,48 +21,6 @@ const CUSTOMER_CREATE = `#graphql
     }
   }
 ` as const;
-
-/**
- * Verify a Cloudflare Turnstile token server-side.
- * Returns true if valid, false otherwise.
- * If no secret key is configured, returns true (graceful degradation).
- */
-async function verifyTurnstile(
-  token: string | null,
-  secretKey: string | undefined,
-  remoteIp?: string,
-): Promise<boolean> {
-  if (!secretKey) {
-    // No Turnstile secret configured — skip verification (honeypot still active)
-    return true;
-  }
-  if (!token) {
-    return false;
-  }
-
-  try {
-    const formData = new URLSearchParams();
-    formData.append("secret", secretKey);
-    formData.append("response", token);
-    if (remoteIp) {
-      formData.append("remoteip", remoteIp);
-    }
-
-    const result = await fetch(
-      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
-      {
-        method: "POST",
-        body: formData,
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      },
-    );
-    const outcome = (await result.json()) as { success: boolean };
-    return outcome.success;
-  } catch {
-    // If Turnstile verification fails (network issue etc), block by default
-    return false;
-  }
-}
 
 export const action: ActionFunction = async ({
   request,
@@ -105,7 +64,7 @@ export const action: ActionFunction = async ({
   const { customerCreate, errors: queryErrors } =
     await context.storefront.mutate<CustomerCreateMutation>(CUSTOMER_CREATE, {
       variables: {
-        input: { email, password: "5hopify" },
+        input: { email, password: crypto.randomUUID() },
       },
     });
 

--- a/app/routes/($locale).api.predictive-search.ts
+++ b/app/routes/($locale).api.predictive-search.ts
@@ -62,7 +62,10 @@ async function fetchPredictiveSearchResults({
     /* */
   }
   const searchTerm = String(body?.get("q") || searchParams.get("q") || "");
-  const limit = Number(body?.get("limit") || searchParams.get("limit") || 10);
+  const limit = Math.min(
+    Number(body?.get("limit") || searchParams.get("limit") || 10) || 10,
+    50,
+  );
   const rawTypes = String(
     body?.get("type") || searchParams.get("type") || "ANY",
   );

--- a/app/routes/($locale).api.products.ts
+++ b/app/routes/($locale).api.products.ts
@@ -39,7 +39,7 @@ export async function loader({
   try {
     const _count = searchParams.get("count");
     if (typeof _count === "string") {
-      count = Number.parseInt(_count, 10);
+      count = Math.min(Math.max(Number.parseInt(_count, 10) || 4, 1), 50);
     }
   } catch (_) {
     // noop

--- a/app/routes/($locale).cart.add.$variantId.ts
+++ b/app/routes/($locale).cart.add.$variantId.ts
@@ -1,13 +1,14 @@
-import type { LoaderFunctionArgs } from "@shopify/remix-oxygen";
-import { data, redirect } from "@shopify/remix-oxygen";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import type { CartLineInput } from "@shopify/hydrogen/storefront-api-types";
 
-export async function loader({ params, context }: LoaderFunctionArgs) {
+export async function action({ params, context }: ActionFunctionArgs) {
   const { cart, session } = context;
 
   try {
     const variantId = params.variantId;
 
-    const inputLines = [
+    const inputLines: CartLineInput[] = [
       {
         merchandiseId: `gid://shopify/ProductVariant/${variantId}`,
         quantity: 1,

--- a/app/routes/($locale).collections.$collectionHandle.tsx
+++ b/app/routes/($locale).collections.$collectionHandle.tsx
@@ -45,9 +45,13 @@ export async function loader({ params, request, context }: LoaderFunctionArgs) {
   const filters = [...searchParams.entries()].reduce((flt, [key, value]) => {
     if (key.startsWith(FILTER_URL_PREFIX)) {
       const filterKey = key.substring(FILTER_URL_PREFIX.length);
-      flt.push({
-        [filterKey]: JSON.parse(value),
-      });
+      try {
+        flt.push({
+          [filterKey]: JSON.parse(value),
+        });
+      } catch {
+        // Skip malformed filter values
+      }
     }
     return flt;
   }, [] as ProductFilter[]);

--- a/app/routes/($locale).products.$productHandle.tsx
+++ b/app/routes/($locale).products.$productHandle.tsx
@@ -23,6 +23,7 @@ import {
 import { getEnhancedSeoMeta } from "~/utils/enhanced-seo-meta";
 import { createJudgeMeReview, getJudgeMeProductReviews } from "~/utils/judgeme";
 import { getRecommendedProducts } from "~/utils/product";
+import { verifyTurnstile } from "~/utils/turnstile.server";
 import {
   redirectIfCombinedListing,
   redirectIfHandleIsLocalized,
@@ -83,13 +84,34 @@ export async function action({
   context: { env },
 }: ActionFunctionArgs) {
   try {
+    const formData = await request.formData();
+
+    // Honeypot check
+    if (formData.get("website")) {
+      return data({ success: true }, { status: 200 });
+    }
+
+    // Turnstile verification
+    const turnstileToken = formData.get("cf-turnstile-response") as string;
+    const turnstileValid = await verifyTurnstile(
+      turnstileToken,
+      env.TURNSTILE_SECRET_KEY,
+      request.headers.get("CF-Connecting-IP") || undefined,
+    );
+    if (!turnstileValid) {
+      return data(
+        { error: "Please complete the verification challenge and try again." },
+        { status: 400 },
+      );
+    }
+
     invariant(
       env.JUDGEME_PRIVATE_API_TOKEN,
       "Missing `JUDGEME_PRIVATE_API_TOKEN`",
     );
 
     const response = await createJudgeMeReview({
-      formData: await request.formData(),
+      formData,
       apiToken: env.JUDGEME_PRIVATE_API_TOKEN,
       shopDomain: env.PUBLIC_STORE_DOMAIN,
     });

--- a/app/routes/($locale).search.tsx
+++ b/app/routes/($locale).search.tsx
@@ -45,9 +45,13 @@ export async function loader({
   const filters = [...searchParams.entries()].reduce((flt, [key, value]) => {
     if (key.startsWith(FILTER_URL_PREFIX)) {
       const filterKey = key.substring(FILTER_URL_PREFIX.length);
-      flt.push({
-        [filterKey]: JSON.parse(value),
-      } as ProductFilter);
+      try {
+        flt.push({
+          [filterKey]: JSON.parse(value),
+        } as ProductFilter);
+      } catch {
+        // Skip malformed filter values
+      }
     }
     return flt;
   }, [] as ProductFilter[]);

--- a/app/utils/judgeme.ts
+++ b/app/utils/judgeme.ts
@@ -104,10 +104,23 @@ export async function createJudgeMeReview({
   );
 }
 
+const ALLOWED_REVIEW_FIELDS = new Set([
+  "id",
+  "name",
+  "email",
+  "rating",
+  "title",
+  "body",
+  "product_id",
+  "reviewer_name_format",
+]);
+
 function formDataToObject(formData: FormData) {
-  const data = {};
+  const data: Record<string, string> = {};
   for (const [key, value] of formData.entries()) {
-    data[key] = value;
+    if (ALLOWED_REVIEW_FIELDS.has(key) && typeof value === "string") {
+      data[key] = value;
+    }
   }
   return data;
 }

--- a/app/utils/turnstile.server.ts
+++ b/app/utils/turnstile.server.ts
@@ -1,0 +1,39 @@
+/**
+ * Verify a Cloudflare Turnstile token server-side.
+ * Returns true if valid, false otherwise.
+ * If no secret key is configured, returns true (graceful degradation).
+ */
+export async function verifyTurnstile(
+  token: string | null,
+  secretKey: string | undefined,
+  remoteIp?: string,
+): Promise<boolean> {
+  if (!secretKey) {
+    return true;
+  }
+  if (!token) {
+    return false;
+  }
+
+  try {
+    const formData = new URLSearchParams();
+    formData.append("secret", secretKey);
+    formData.append("response", token);
+    if (remoteIp) {
+      formData.append("remoteip", remoteIp);
+    }
+
+    const result = await fetch(
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+      {
+        method: "POST",
+        body: formData,
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      },
+    );
+    const outcome = (await result.json()) as { success: boolean };
+    return outcome.success;
+  } catch {
+    return false;
+  }
+}

--- a/app/weaverse/csp.ts
+++ b/app/weaverse/csp.ts
@@ -13,20 +13,38 @@ export function getWeaverseCsp(request: Request, context: AppLoadContext) {
   const updatedCsp: {
     [x: string]: string[] | string | boolean;
   } = {
-    defaultSrc: [
+    defaultSrc: [...weaverseHosts],
+    imgSrc: [
       "data:",
+      "cdn.alireviews.io",
+      ...weaverseHosts,
+    ],
+    mediaSrc: [
       "*.youtube.com",
       "*.youtu.be",
       "*.vimeo.com",
-      "*.google.com",
-      "*.google-analytics.com",
-      "*.googletagmanager.com",
-      "cdn.alireviews.io",
-      "cdn.jsdelivr.net",
-      "*.alicdn.com",
       ...weaverseHosts,
     ],
-    connectSrc: ["vimeo.com", "*.google-analytics.com", ...weaverseHosts],
+    frameSrc: [
+      "*.youtube.com",
+      "*.youtu.be",
+      "*.vimeo.com",
+      "challenges.cloudflare.com",
+      ...weaverseHosts,
+    ],
+    scriptSrc: [
+      "*.googletagmanager.com",
+      "*.google-analytics.com",
+      "challenges.cloudflare.com",
+      ...weaverseHosts,
+    ],
+    connectSrc: [
+      "vimeo.com",
+      "*.google-analytics.com",
+      "*.googletagmanager.com",
+      "challenges.cloudflare.com",
+      ...weaverseHosts,
+    ],
     styleSrc: weaverseHosts,
   };
   if (isDesignMode) {

--- a/server.ts
+++ b/server.ts
@@ -116,6 +116,18 @@ export default {
 
       const response = await handleRequest(request);
 
+      // Security headers
+      response.headers.set("X-Frame-Options", "SAMEORIGIN");
+      response.headers.set("X-Content-Type-Options", "nosniff");
+      response.headers.set(
+        "Referrer-Policy",
+        "strict-origin-when-cross-origin",
+      );
+      response.headers.set(
+        "Permissions-Policy",
+        "camera=(), microphone=(), geolocation=()",
+      );
+
       if (appLoadContext.session.isPending) {
         response.headers.set(
           "Set-Cookie",
@@ -202,6 +214,7 @@ class AppSession implements HydrogenSession {
         httpOnly: true,
         path: "/",
         sameSite: "lax",
+        secure: true,
         secrets,
       },
     });


### PR DESCRIPTION
## Summary
- **CRITICAL:** Replace hardcoded `"5hopify"` password in newsletter signup with `crypto.randomUUID()` per subscriber
- **CRITICAL:** Enforce Content-Security-Policy (was Report-Only) and tighten directives — moved broad `defaultSrc` domains to specific `scriptSrc`, `frameSrc`, `mediaSrc`, `imgSrc`; removed `cdn.jsdelivr.net` and `data:` from `defaultSrc`
- **CRITICAL:** Lock down open GraphQL proxy route with API version allowlist, same-origin check, and safe header filtering
- **HIGH:** Add `secure: true` to session cookie + security response headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`)
- **HIGH:** Convert cart-add route from GET `loader` to POST `action` (CSRF fix) and fix imports to `react-router`
- **HIGH:** Add Turnstile verification + honeypot anti-spam to JudgeMe review submissions
- **HIGH:** Whitelist allowed fields in JudgeMe `formDataToObject` (was forwarding ALL form fields to external API)
- **HIGH:** Cap unbounded `count`/`limit` params on products API (max 50) and predictive search API (max 50)
- **MEDIUM:** Wrap uncaught `JSON.parse` on user-controlled URL filter params in collection and search routes
- Extract shared `verifyTurnstile()` utility to `app/utils/turnstile.server.ts`

## Files changed (13)
| File | Change |
|------|--------|
| `server.ts` | Secure cookie flag, security headers |
| `app/entry.server.tsx` | CSP enforced |
| `app/weaverse/csp.ts` | Tightened CSP directives |
| `app/routes/($locale).api.customer.ts` | Random password, shared Turnstile import |
| `app/routes/($locale).api.$version.[graphql.json].tsx` | Proxy lockdown |
| `app/routes/($locale).cart.add.$variantId.ts` | GET→POST, react-router imports |
| `app/routes/($locale).products.$productHandle.tsx` | Turnstile + honeypot on reviews |
| `app/routes/($locale).api.products.ts` | Capped count param |
| `app/routes/($locale).api.predictive-search.ts` | Capped limit param |
| `app/routes/($locale).collections.$collectionHandle.tsx` | JSON.parse try/catch |
| `app/routes/($locale).search.tsx` | JSON.parse try/catch |
| `app/utils/judgeme.ts` | Field allowlist on review form data |
| `app/utils/turnstile.server.ts` | New shared Turnstile utility |

## Test plan
- [ ] Verify homepage, product pages, and collections load without CSP errors in browser console
- [ ] Test newsletter signup (footer + popup) — should still create customer
- [ ] Test predictive search works with default and explicit `limit` values
- [ ] Test collection filter URLs with valid and malformed filter params
- [ ] Verify Weaverse Studio design mode still works (frameAncestors bypass)
- [ ] Confirm GTM/GA4 tracking fires (check Network tab for analytics requests)
- [ ] Test Cloudflare Turnstile challenge renders on review forms
- [ ] Verify cart add still works from product pages (now requires POST)
- [ ] Check GraphQL checkout flow still functions with allowed API versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)