### PR TITLE
Add top-10 customer spreadsheet template and ranking notes

### DIFF
--- a/reports/top_10_customers.csv
+++ b/reports/top_10_customers.csv
@@ -1,0 +1,11 @@
+rank,name,metric,period,segment,notes
+1,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+2,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+3,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+4,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+5,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+6,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+7,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+8,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+9,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment
+10,,N/A,N/A,N/A,Unable to retrieve customer data from database in this environment

--- a/reports/top_10_customers_notes.md
+++ b/reports/top_10_customers_notes.md
@@ -1,0 +1,10 @@
+# Top 10 Customers Ranking Logic & Caveats
+
+- Intended ranking metric: **lifetime customer revenue** (Shopify Admin `customers` sorted by `TOTAL_SPENT`, descending), because it is the most direct and reliable business value metric available for customer ranking.
+- Units: USD (or the store currency returned by Shopify).
+- Period: Lifetime (all-time) unless a time-bounded metric is explicitly requested.
+
+## Caveats
+
+- Database/API credentials were not available in this runtime, so no customer records could be retrieved.
+- As required, no values were guessed; unknown fields are left blank or marked `N/A`.


### PR DESCRIPTION
### Motivation
- Provide a ready spreadsheet for the store's top 10 customers using a reliable business metric and capture methodology and caveats when live customer data cannot be retrieved.

### Description
- Add `reports/top_10_customers.csv` (columns: `rank`, `name`, `metric`, `period`, `segment`, `notes`) and `reports/top_10_customers_notes.md` which documents the intended ranking metric (Shopify `TOTAL_SPENT` / lifetime revenue) and the rule to leave unknowns blank or `N/A`; spreadsheet path is `/workspace/moderncre8ve-hydrogen/reports/top_10_customers.csv`.

### Testing
- Attempted an automated Shopify GraphQL query (scripted `requests.post`) which failed due to missing `SHOPIFY_ADMIN_API_TOKEN` in the environment and a proxy `403`, so no live customer data could be retrieved; this failure is noted in the caveats file. 
- Verified the generated files and their contents locally with `wc -l`, `sed -n` and `nl`, and the CSV/note files were created and contain the placeholder `N/A` entries as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8360c7f0c832c97a077f6a13310bc)