### PR TITLE
chore: remove Ahrefs MCP server, fix Shopify MCP path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,23 +1,13 @@
 {
   "mcpServers": {
-    "ahrefs": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["--prefix=~/.global-node-modules", "@ahrefs/mcp"],
-      "env": {
-        "API_KEY": "${AHREFS_API_KEY}"
-      }
-    },
     "figma": {
       "type": "http",
       "url": "https://mcp.figma.com/mcp"
     },
     "shopify": {
       "type": "stdio",
-      "command": "node",
-      "args": [
-        "/Users/rwlarow/.global-node-modules/node_modules/@wolfielabs/shopify-storefront-mcp-server/dist/index.js"
-      ],
+      "command": "npx",
+      "args": ["-y", "@wolfielabs/shopify-storefront-mcp-server"],
       "env": {
         "SHOPIFY_STOREFRONT_ACCESS_TOKEN": "${PUBLIC_STOREFRONT_API_TOKEN}",
         "SHOPIFY_STORE_DOMAIN": "${PUBLIC_STORE_DOMAIN}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,10 @@ Handcrafted modern furniture (mid-century, Scandinavian, Japandi) — moderncre8
 - **SEO Truth Layer:** `github.com/rwlarow-ui/moderncre8ve-seo-truth-layer` (weekly pipeline)
 
 ### MCP Servers
-Configured in `.mcp.json`: Ahrefs, Figma, Shopify (Storefront API), Shopify Dev (docs/schema).
+Configured in `.mcp.json`: Figma, Shopify (Storefront API), Shopify Dev (docs/schema).
 Composer and Crypto.com servers visible in sessions are from another project — irrelevant here.
+
+> **Ahrefs (informational):** The Ahrefs MCP connection was removed (was a stdio server in `.mcp.json`). Historical Ahrefs keyword data (March 2026) still informs SEO copy — see the comment in `app/utils/collection-seo-descriptions.ts` — and `AhrefsBot`/`AhrefsSiteAudit` crawl directives remain in `app/routes/[robots.txt].tsx`. Neither depends on the live MCP connection.
 
 ## Development Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ---
 
+## Unreleased
+
+### Developer Tooling & Docs
+- Removed the dead **Ahrefs MCP server** from `.mcp.json` (connection retired). Ahrefs is now informational only — the `AhrefsBot`/`AhrefsSiteAudit` crawl directives in `app/routes/[robots.txt].tsx` and the March-2026 keyword-data comment in `app/utils/collection-seo-descriptions.ts` are unaffected (neither uses the MCP).
+- Repointed the **Shopify Storefront MCP** from a hardcoded `/Users/rwlarow/…` absolute path (nonexistent on other machines) to `npx -y @wolfielabs/shopify-storefront-mcp-server` so it resolves anywhere.
+- Updated `CLAUDE.md` / `AGENTS.md` MCP server lists and added an "Ahrefs (informational)" note.
+
+_No storefront runtime impact — all changes are dev tooling / documentation._
+
+---
+
 ## 1.4.2 — 2026-03-19
 
 ### Security Hardening

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,10 @@ Handcrafted modern furniture (mid-century, Scandinavian, Japandi) — moderncre8
 - **SEO Truth Layer:** `seo-truth-layer/` (weekly pipeline, merged into this repo)
 
 ### MCP Servers
-Configured in `.mcp.json`: Ahrefs, Figma, Shopify (Storefront API), Shopify Dev (docs/schema), Weaverse (docs/API at `https://docs.weaverse.io/mcp`).
+Configured in `.mcp.json`: Figma, Shopify (Storefront API), Shopify Dev (docs/schema), Weaverse (docs/API at `https://docs.weaverse.io/mcp`).
 Composer and Crypto.com servers visible in sessions are from another project — irrelevant here.
+
+> **Ahrefs (informational):** The Ahrefs MCP connection was removed (was a stdio server in `.mcp.json`). Historical Ahrefs keyword data (March 2026) still informs SEO copy — see the comment in `app/utils/collection-seo-descriptions.ts` — and `AhrefsBot`/`AhrefsSiteAudit` crawl directives remain in `app/routes/[robots.txt].tsx`. Neither depends on the live MCP connection.
 
 ## Development Commands
 


### PR DESCRIPTION
## Summary
Dev-tooling/docs cleanup. **No storefront runtime impact** — every changed file is dev tooling or documentation; nothing ships to the Oxygen bundle.

- **Removed the dead Ahrefs MCP server** from `.mcp.json` (the connection was retired; it was failing to start). Ahrefs is now *informational only* — the `AhrefsBot`/`AhrefsSiteAudit` crawl directives in `app/routes/[robots.txt].tsx` and the March-2026 keyword-data comment in `app/utils/collection-seo-descriptions.ts` are intentionally kept (neither depends on the MCP).
- **Fixed the Shopify Storefront MCP path:** it pointed at a hardcoded `/Users/rwlarow/…` absolute path that doesn't exist on other machines (caused a `-32000` connect failure). Repointed to `npx -y @wolfielabs/shopify-storefront-mcp-server` so it resolves anywhere. Verified the package publishes that bin on npm.
- Updated `CLAUDE.md` / `AGENTS.md` MCP server lists + added an "Ahrefs (informational)" note.
- Added an **Unreleased** CHANGELOG entry.

## Note on the H1 work
The branch name references a homepage-H1 investigation. On rigorous re-check the live homepage already has **exactly one `<h1>`** (the patched hero) — the apparent "3 H1s" was a grep/regex artifact. No code change was needed, so none was made.

## Verification
- `.mcp.json` re-validated as JSON; no `ahrefs` key; `shopify` uses `npx`.
- `@wolfielabs/shopify-storefront-mcp-server` confirmed on npm (bin → `dist/index.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)